### PR TITLE
dk - copy backend CRUD operations from team01 for HelpRequests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,160 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for HelpRequest */
+@Tag(name = "HelpRequest")
+@RequestMapping("/api/helprequest")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+
+  @Autowired HelpRequestRepository helpRequestRepository;
+
+  /**
+   * List all help requests
+   *
+   * @return an iterable of HelpRequest
+   */
+  @Operation(summary = "List all help requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<HelpRequest> allHelpRequests() {
+    Iterable<HelpRequest> helpRequests = helpRequestRepository.findAll();
+    return helpRequests;
+  }
+
+  /**
+   * Get a single date by id
+   *
+   * @param id the id of the request
+   * @return a HelpRequest
+   */
+  @Operation(summary = "Get a single request")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public HelpRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    return helpRequest;
+  }
+
+  /**
+   * Create a new help request
+   *
+   * @param requesterEmail
+   * @param teamId
+   * @param tableOrBreakoutRoom
+   * @param requestTime
+   * @param explanation
+   * @param solved
+   * @return
+   */
+  @Operation(summary = "Create a new help request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public HelpRequest postHelpRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "teamId") @RequestParam String teamId,
+      @Parameter(name = "tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(name = "solved") @RequestParam boolean solved,
+      @Parameter(
+              name = "requestTime",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("requestTime")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime requestTime)
+      throws JsonProcessingException {
+
+    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    // See: https://www.baeldung.com/spring-date-parameters
+
+    log.info("requestTime={}", requestTime);
+
+    HelpRequest helpRequest = new HelpRequest();
+    helpRequest.setRequesterEmail(requesterEmail);
+    helpRequest.setTeamId(teamId);
+    helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+    helpRequest.setRequestTime(requestTime);
+    helpRequest.setExplanation(explanation);
+    helpRequest.setSolved(solved);
+
+    HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+    return savedHelpRequest;
+  }
+
+  /**
+   * Delete a HelpRequest
+   *
+   * @param id the id of the request to delete
+   * @return a message indicating the date was deleted
+   */
+  @Operation(summary = "Delete a HelpRequest")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteHelpRequest(@Parameter(name = "id") @RequestParam Long id) {
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    helpRequestRepository.delete(helpRequest);
+    return genericMessage("HelpRequest with id %s deleted".formatted(id));
+  }
+
+  /**
+   * Update a single date
+   *
+   * @param id id of the date to update
+   * @param incoming the new date
+   * @return the updated date object
+   */
+  @Operation(summary = "Update a single request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public HelpRequest updateHelpRequest(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid HelpRequest incoming) {
+
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    helpRequest.setRequesterEmail(incoming.getRequesterEmail());
+    helpRequest.setTeamId(incoming.getTeamId());
+    helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+    helpRequest.setRequestTime(incoming.getRequestTime());
+    helpRequest.setExplanation(incoming.getExplanation());
+    helpRequest.setSolved(incoming.getSolved());
+
+    helpRequestRepository.save(helpRequest);
+
+    return helpRequest;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a Help Request */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/** The HelpRequestRepository is a repository for HelpRequest entities. */
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {}

--- a/src/main/resources/db/migration/changes/HelpRequests.json
+++ b/src/main/resources/db/migration/changes/HelpRequests.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "HelpRequest-1",
+          "author": "dkim876",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "HELPREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "HELPREQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TEAM_ID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TABLE_OR_BREAKOUT_ROOM",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUEST_TIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "SOLVED",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "HELPREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,359 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+  @MockBean HelpRequestRepository helpRequestRepository;
+
+  @MockBean UserRepository userRepository;
+
+  // Authorization tests for /api/helprequest/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/helprequest/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/helprequest/all")).andExpect(status().is(200)); // logged
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/helprequest?id=7"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
+
+  //   Authorization tests for /api/helprequest/post
+  //   (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/helprequest/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(post("/api/helprequest/post"))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .requesterEmail("test@ucsb.edu")
+            .teamId("testId")
+            .tableOrBreakoutRoom("test_table")
+            .requestTime(ldt)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequest?id=7")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(helpRequestRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(helpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequest?id=7")).andExpect(status().isNotFound()).andReturn();
+
+    // assert
+
+    verify(helpRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("HelpRequest with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_helprequests() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .requesterEmail("test1@ucsb.edu")
+            .teamId("testId1")
+            .tableOrBreakoutRoom("test_table1")
+            .requestTime(ldt1)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+    HelpRequest helpRequest2 =
+        HelpRequest.builder()
+            .requesterEmail("test2@ucsb.edu")
+            .teamId("testId2")
+            .tableOrBreakoutRoom("test_table2")
+            .requestTime(ldt2)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    ArrayList<HelpRequest> expectedRequests = new ArrayList<>();
+    expectedRequests.addAll(Arrays.asList(helpRequest1, helpRequest1));
+
+    when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequest/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(helpRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .requesterEmail("test1@ucsb.edu")
+            .teamId("testId1")
+            .tableOrBreakoutRoom("test_table1")
+            .requestTime(ldt1)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/helprequest/post?requesterEmail=test1@ucsb.edu&teamId=testId1&tableOrBreakoutRoom=test_table1&requestTime=2022-01-03T00:00:00&explanation=This is a test!&solved=true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).save(helpRequest1);
+    String expectedJson = mapper.writeValueAsString(helpRequest1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_request() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .requesterEmail("test1@ucsb.edu")
+            .teamId("testId1")
+            .tableOrBreakoutRoom("test_table1")
+            .requestTime(ldt1)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helpRequest1));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/helprequest?id=15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findById(15L);
+    verify(helpRequestRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("HelpRequest with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+
+    when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/helprequest?id=15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("HelpRequest with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_helprequest() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+    HelpRequest helpRequestOrig =
+        HelpRequest.builder()
+            .requesterEmail("test1@ucsb.edu")
+            .teamId("testId1")
+            .tableOrBreakoutRoom("test_table1")
+            .requestTime(ldt1)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    HelpRequest helpRequestEdited =
+        HelpRequest.builder()
+            .requesterEmail("test2@ucsb.edu")
+            .teamId("testId2")
+            .tableOrBreakoutRoom("test_table2")
+            .requestTime(ldt2)
+            .explanation("This is a test 2!")
+            .solved(false)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+    when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.of(helpRequestOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/helprequest?id=67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findById(67L);
+    verify(helpRequestRepository, times(1)).save(helpRequestEdited); // should be saved with
+    //   correct user
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_helprequest_that_does_not_exist() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    HelpRequest helpRequestEdited =
+        HelpRequest.builder()
+            .requesterEmail("test1@ucsb.edu")
+            .teamId("testId1")
+            .tableOrBreakoutRoom("test_table1")
+            .requestTime(ldt1)
+            .explanation("This is a test!")
+            .solved(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+    when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/helprequest?id=67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("HelpRequest with id 67 not found", json.get("message"));
+  }
+}


### PR DESCRIPTION
Closes #44 

In this PR, we copy over the entity, repository, controller, controller tests, and db migration file (i.e. the entire backend CRUD functionality) for the HelpRequests table, from the previous project.

<img width="475" height="321" alt="image" src="https://github.com/user-attachments/assets/932eafbc-374d-41ec-a9c7-81e4b9761bb1" />
